### PR TITLE
Move secrets into connector proxy

### DIFF
--- a/app.py
+++ b/app.py
@@ -97,7 +97,7 @@ def do_command(plugin_display_name, command_name):
 
     params = request.args.to_dict()
     try:
-        result = command(**params).execute()
+        result = command(**params).execute(app.config)
     except Exception as e:
         return json_error_response(f'Error encountered when executing {plugin_display_name}:{command_name} {str(e)}',
                         status=404)

--- a/connectors/connector-aws/connector_aws/commands/addDynamoItem.py
+++ b/connectors/connector-aws/connector_aws/commands/addDynamoItem.py
@@ -31,7 +31,7 @@ class AddDynamoItem:
         self.table = self.dynamodb.Table(table_name)
         self.item_data = json.loads(item_data)
 
-    def execute(self):
+    def execute(self, config):
         result = self.table.put_item(Item=self.item_data)
         if 'ResponseMetadata' in result:
             del result['ResponseMetadata']

--- a/connectors/connector-aws/connector_aws/commands/queryDynamoTable.py
+++ b/connectors/connector-aws/connector_aws/commands/queryDynamoTable.py
@@ -23,7 +23,7 @@ class QueryDynamoTable:
         self.table = self.dynamodb.Table(table_name)
         self.key = key
 
-    def execute(self):
+    def execute(self, config):
         result = self.table.get_item(Key={"primaryKeyName": self.key})
         if 'ResponseMetadata' in result:
             del result['ResponseMetadata']

--- a/connectors/connector-aws/connector_aws/commands/scanDynamoTable.py
+++ b/connectors/connector-aws/connector_aws/commands/scanDynamoTable.py
@@ -20,7 +20,7 @@ class ScanDynamoTable:
         self.dynamodb = SimpleAuth('dynamodb', access_key, secret_key).get_resource()
         self.table = self.dynamodb.Table(table_name)
 
-    def execute(self):
+    def execute(self, config):
         result = self.table.scan()
         if 'ResponseMetadata' in result:
             del result['ResponseMetadata']

--- a/connectors/connector-aws/connector_aws/commands/uploadFile.py
+++ b/connectors/connector-aws/connector_aws/commands/uploadFile.py
@@ -23,7 +23,7 @@ class UploadFileData:
         self.bucket = bucket
         self.object_name = object_name
 
-    def execute(self):
+    def execute(self, config):
 
         # Upload the file
         try:

--- a/connectors/connector-bamboohr/connector_bamboohr/commands/getPayRate.py
+++ b/connectors/connector-bamboohr/connector_bamboohr/commands/getPayRate.py
@@ -18,7 +18,7 @@ class GetPayRate:
         self.subdomain = subdomain
         self.employee_id = employee_id
 
-    def execute(self):
+    def execute(self, config):
         url = f'https://api.bamboohr.com/api/gateway.php/{self.subdomain}/v1/employees/{self.employee_id}'
         headers = {'Accept': 'application/json'}
         params = {'fields': 'payRate', 'onlyCurrent': 'true'}

--- a/connectors/connector-bamboohr/connector_bamboohr/commands/getPayRate.py
+++ b/connectors/connector-bamboohr/connector_bamboohr/commands/getPayRate.py
@@ -13,16 +13,17 @@ import requests
 # }
 
 class GetPayRate:
-    def __init__(self, api_key: str, subdomain: str, employee_id: str):
-        self.api_key = api_key
-        self.subdomain = subdomain
+    def __init__(self, employee_id: str):
         self.employee_id = employee_id
 
     def execute(self, config):
-        url = f'https://api.bamboohr.com/api/gateway.php/{self.subdomain}/v1/employees/{self.employee_id}'
+        api_key = config['BAMBOOHR_API_KEY']
+        subdomain = config['BAMBOOHR_SUBDOMAIN']
+
+        url = f'https://api.bamboohr.com/api/gateway.php/{subdomain}/v1/employees/{self.employee_id}'
         headers = {'Accept': 'application/json'}
         params = {'fields': 'payRate', 'onlyCurrent': 'true'}
-        auth = (self.api_key, 'x')
+        auth = (api_key, 'x')
 
         try:
             raw_response = requests.get(url, params, headers=headers, auth=auth)

--- a/connectors/connector-createpdf/connector_createpdf/commands/create.py
+++ b/connectors/connector-createpdf/connector_createpdf/commands/create.py
@@ -5,7 +5,7 @@ class CreatePDF:
     def __init__(self, template: str):
         self.template = template
 
-    def execute(self):
+    def execute(self, config):
         buf = BytesIO()
 
         pisa_status = pisa.CreatePDF(self.template, dest=buf)

--- a/connectors/connector-invoicepdf/connector_invoicepdf/commands/createAndUploadToS3.py
+++ b/connectors/connector-invoicepdf/connector_invoicepdf/commands/createAndUploadToS3.py
@@ -2,20 +2,20 @@ from connector_aws.commands.uploadFile import UploadFileData
 from connector_createpdf.commands.create import CreatePDF
 
 class CreateAndUploadToS3:
-    def __init__(self, template: str, name: str, amount: str, 
-        aws_bucket: str, aws_object_name: str, aws_access_key_id: str, aws_secret_access_key: str):
+    def __init__(self, template: str, name: str, amount: str, aws_object_name: str):
         
         self.template = template
         self.name = name
         self.amount = amount
-        self.aws_bucket = aws_bucket
         self.aws_object_name = aws_object_name
-        self.aws_access_key_id = aws_access_key_id
-        self.aws_secret_access_key = aws_secret_access_key
 
-    def execute(self):
+    def execute(self, config):
+        aws_access_key_id = config['AWS_ACCESS_KEY_ID']
+        aws_secret_access_key = config['AWS_SECRET_ACCESS_KEY']
+        aws_bucket = config['AWS_INVOICE_S3_BUCKET']
+
         pdf_data = self.template.format(name=self.name, amount=self.amount)
-        pdf_result = CreatePDF(pdf_data).execute()
+        pdf_result = CreatePDF(pdf_data).execute(config)
 
         if pdf_result['status'] != '200':
             return {
@@ -24,11 +24,11 @@ class CreateAndUploadToS3:
                 'mimetype': 'application/json',
             }
 
-        aws_result = UploadFileData(self.aws_access_key_id, 
-            self.aws_secret_access_key, 
+        aws_result = UploadFileData(aws_access_key_id, 
+            aws_secret_access_key, 
             pdf_result['response'],
-            self.aws_bucket,
-            self.aws_object_name).execute()
+            aws_bucket,
+            self.aws_object_name).execute(config)
 
         if aws_result['status'] != '200':
             return aws_result

--- a/connectors/connector-waku/connector_waku/commands/sendMessage.py
+++ b/connectors/connector-waku/connector_waku/commands/sendMessage.py
@@ -10,7 +10,7 @@ class SendMessage:
     message_type: str
     recipient: str
 
-    def execute(self):
+    def execute(self, config):
         url = f'{current_app.config["WAKU_PROXY_BASE_URL"]}/sendMessage'
         headers = {'Accept': 'application/json', 'Content-type': 'application/json'}
         request_body = {"message": self.message, "recipient": self.recipient, "message_type": self.message_type}

--- a/connectors/connector-xero/connector_xero/commands/createInvoice.py
+++ b/connectors/connector-xero/connector_xero/commands/createInvoice.py
@@ -133,8 +133,6 @@ from xero_python.api_client.serializer import serialize
 
 class CreateInvoice:
     def __init__(self, 
-        client_id: str, 
-        client_secret: str, 
         access_token, 
 
         description: str,
@@ -147,8 +145,6 @@ class CreateInvoice:
         #due_date: str,
         #account_code: str,
     ):
-        self.client_id = client_id
-        self.client_secret = client_secret
         self.access_token = access_token
         self.description = description
         self.contact_name = contact_name
@@ -157,6 +153,8 @@ class CreateInvoice:
 
     def execute(self, config):
         """Creates an invoice in xero."""
+        client_id = config['XERO_CLIENT_ID']
+        client_secret = config['XERO_CLIENT_SECRET']
 
         access_token = json.loads(self.access_token)
 
@@ -164,7 +162,7 @@ class CreateInvoice:
             Configuration(
                 debug=True,
                 oauth2_token=OAuth2Token(
-                    client_id=self.client_id, client_secret=self.client_secret
+                    client_id=sclient_id, client_secret=client_secret
                 ),
             ),
             pool_threads=1,

--- a/connectors/connector-xero/connector_xero/commands/createInvoice.py
+++ b/connectors/connector-xero/connector_xero/commands/createInvoice.py
@@ -155,7 +155,7 @@ class CreateInvoice:
         self.contact_email = contact_email
         self.amount = amount
 
-    def execute(self):
+    def execute(self, config):
         """Creates an invoice in xero."""
 
         access_token = json.loads(self.access_token)


### PR DESCRIPTION
This moves the aws/bamboohr/xero secrets into config loaded into the connector proxy instead of runtime parameters that are passed into the service. Each connector is passed the proxy's config object into its execute method. I thought about providing a subset of the config, but ultimately this is code we are writing and the current flask app could be retrieved anyway. If we ever open this up to dynamic loading of 3rd party connectors we will want to rethink this to prevent exfiltration.