### PR TITLE
Refresh Xero OAuth token

### DIFF
--- a/connectors/connector-xero/connector_xero/commands/createInvoice.py
+++ b/connectors/connector-xero/connector_xero/commands/createInvoice.py
@@ -189,14 +189,11 @@ class CreateInvoice:
         @api_client.oauth2_token_saver
         def store_xero_oauth2_token(token):
             """Store_xero_oauth2_token."""
-            print(f"----1.5 {token['expires_at']}")
             token_store[token_store_key] = token # noqa
 
         store_xero_oauth2_token(access_token)
 
-        print(f"----1 {token_store[token_store_key]['expires_at']}")
         api_client.refresh_oauth2_token()
-        print(f"----2 {token_store[token_store_key]['expires_at']}")
 
         api_instance = AccountingApi(api_client)
         summarize_errors = "True"
@@ -237,7 +234,7 @@ class CreateInvoice:
             )
             response = json.dumps({
                 "api_response": serialize(created_invoices),
-                "token_set": obtain_xero_oauth2_token(),
+                "refreshed_token_set": obtain_xero_oauth2_token(),
                 "auth": "xero/OAuth",
             })
             status = 200


### PR DESCRIPTION
~There is an upcoming pr planned for spiff-arena where the `service_task_service` will handle this new response format and save the refreshed token_set using the existing auth secret key. Marking this as draft until that PR is ready.~ [Arena PR is up](https://github.com/sartography/spiff-arena/pull/6)

This change change follows Xero's recommendation of refreshing the token before each api call. The refreshed token is then sent back to the backend to be updated in the secret store.

I'd like to go back and refactor some of the OAuth handling here to make future OAuth based connectors a little easier to implement, but since there was only Xero and a demo coming up I didn't want to spend the time now. Once things settle a bit I'd like to move some of this logic up into the generic driver code - similar to how the OAuth login flow is handled.