### PR TITLE
Drop the need for schema to be a json string

### DIFF
--- a/connectors/connector-postgresql/connector_postgresql/commands/createTable.py
+++ b/connectors/connector-postgresql/connector_postgresql/commands/createTable.py
@@ -8,7 +8,7 @@ class CreateTable(BaseCommand):
     def __init__(self, table_name: str, schema: str):
         """__init__."""
         self.table_name = table_name
-        self.schema = json.loads(schema)
+        self.schema = schema
 
     def execute(self, config, task_data):
 

--- a/connectors/connector-postgresql/connector_postgresql/commands/createTable.py
+++ b/connectors/connector-postgresql/connector_postgresql/commands/createTable.py
@@ -1,11 +1,14 @@
 import json
 
+from typing import Any
+from typing import Dict
+
 from connector_postgresql.baseCommand import BaseCommand
 
 class CreateTable(BaseCommand):
     """CreateTable."""
 
-    def __init__(self, table_name: str, schema: str):
+    def __init__(self, table_name: str, schema: Dict[str, Any]):
         """__init__."""
         self.table_name = table_name
         self.schema = schema

--- a/connectors/connector-postgresql/connector_postgresql/commands/deleteValues.py
+++ b/connectors/connector-postgresql/connector_postgresql/commands/deleteValues.py
@@ -8,7 +8,7 @@ class DeleteValues(BaseCommand):
     def __init__(self, table_name: str, schema: str):
         """__init__."""
         self.table_name = table_name
-        self.schema = json.loads(schema)
+        self.schema = schema
 
     def execute(self, config, task_data):
         where_clause, values = self.build_where_clause(self.schema)

--- a/connectors/connector-postgresql/connector_postgresql/commands/deleteValues.py
+++ b/connectors/connector-postgresql/connector_postgresql/commands/deleteValues.py
@@ -1,11 +1,14 @@
 import json
 
+from typing import Any
+from typing import Dict
+
 from connector_postgresql.baseCommand import BaseCommand
 
 class DeleteValues(BaseCommand):
     """DeleteValues."""
 
-    def __init__(self, table_name: str, schema: str):
+    def __init__(self, table_name: str, schema: Dict[str, Any]):
         """__init__."""
         self.table_name = table_name
         self.schema = schema

--- a/connectors/connector-postgresql/connector_postgresql/commands/insertValues.py
+++ b/connectors/connector-postgresql/connector_postgresql/commands/insertValues.py
@@ -1,11 +1,14 @@
 import json
 
+from typing import Any
+from typing import Dict
+
 from connector_postgresql.baseCommand import BaseCommand
 
 class InsertValues(BaseCommand):
     """InsertValues."""
 
-    def __init__(self, table_name: str, schema: str):
+    def __init__(self, table_name: str, schema: Dict[str, Any]):
         """__init__."""
         self.table_name = table_name
         self.schema = schema

--- a/connectors/connector-postgresql/connector_postgresql/commands/insertValues.py
+++ b/connectors/connector-postgresql/connector_postgresql/commands/insertValues.py
@@ -8,7 +8,7 @@ class InsertValues(BaseCommand):
     def __init__(self, table_name: str, schema: str):
         """__init__."""
         self.table_name = table_name
-        self.schema = json.loads(schema)
+        self.schema = schema
 
     def execute(self, config, task_data):
         columns = ",".join(self.schema["columns"])

--- a/connectors/connector-postgresql/connector_postgresql/commands/selectValues.py
+++ b/connectors/connector-postgresql/connector_postgresql/commands/selectValues.py
@@ -8,7 +8,7 @@ class SelectValues(BaseCommand):
     def __init__(self, table_name: str, schema: str):
         """__init__."""
         self.table_name = table_name
-        self.schema = json.loads(schema)
+        self.schema = schema
 
     def execute(self, config, task_data):
 

--- a/connectors/connector-postgresql/connector_postgresql/commands/selectValues.py
+++ b/connectors/connector-postgresql/connector_postgresql/commands/selectValues.py
@@ -1,11 +1,14 @@
 import json
 
+from typing import Any
+from typing import Dict
+
 from connector_postgresql.baseCommand import BaseCommand
 
 class SelectValues(BaseCommand):
     """SelectValues."""
 
-    def __init__(self, table_name: str, schema: str):
+    def __init__(self, table_name: str, schema: Dict[str, Any]):
         """__init__."""
         self.table_name = table_name
         self.schema = schema

--- a/connectors/connector-postgresql/connector_postgresql/commands/updateValues.py
+++ b/connectors/connector-postgresql/connector_postgresql/commands/updateValues.py
@@ -1,11 +1,14 @@
 import json
 
+from typing import Any
+from typing import Dict
+
 from connector_postgresql.baseCommand import BaseCommand
 
 class UpdateValues(BaseCommand):
     """UpdateValues."""
 
-    def __init__(self, table_name: str, schema: str):
+    def __init__(self, table_name: str, schema: Dict[str, Any]):
         """__init__."""
         self.table_name = table_name
         self.schema = schema

--- a/connectors/connector-postgresql/connector_postgresql/commands/updateValues.py
+++ b/connectors/connector-postgresql/connector_postgresql/commands/updateValues.py
@@ -8,7 +8,7 @@ class UpdateValues(BaseCommand):
     def __init__(self, table_name: str, schema: str):
         """__init__."""
         self.table_name = table_name
-        self.schema = json.loads(schema)
+        self.schema = schema
 
     def execute(self, config, task_data):
         set_clause, values = self._build_set_clause(self.schema)


### PR DESCRIPTION
Currently the postgres connector requires a json string to be provided which means variable interpolation requires a tedious f string (or similar) syntax. This allows a dictionary to be used instead.