### PR TITLE
Allow setting column types, add README

### DIFF
--- a/connectors/connector-postgresql/README.md
+++ b/connectors/connector-postgresql/README.md
@@ -1,0 +1,46 @@
+# Postgres Connector
+
+## Commands
+
+### Create Table
+
+Creates a table with the provided column names and their [types](https://www.postgresql.org/docs/current/datatype.html).
+
+The schema parameter expects a key called `column_definitions`. The value associated with this key is a list of dictionaries, each containing the `name` and `type` of a column.
+
+As an example, to create a table like:
+
+```
+dev=# \d states;
+                       Table "public.states"
+ Column  |          Type          | Collation | Nullable | Default 
+---------+------------------------+-----------+----------+---------
+ country | character varying(255) |           |          | 
+ state   | character varying(13)  |           |          | 
+ abbrev  | character(2)           |           |          | 
+ somenum | integer                |           |          | 
+
+```
+
+The schema passed to the connector would be:
+
+```
+{"column_definitions": [
+    {
+        "name": "country",
+        "type": "varchar(255)",
+    },
+    {
+        "name": "state",
+        "type": "varchar(13)",
+    },
+    {
+        "name": "abbrev",
+        "type": "char(2)",
+    },
+    {
+        "name": "somenum",
+        "type": "int",
+    }
+]}
+```

--- a/connectors/connector-postgresql/README.md
+++ b/connectors/connector-postgresql/README.md
@@ -113,3 +113,74 @@ The schema passed to the connector would be:
   ]
 }
 ```
+### SelectValues
+
+Additional parameters:
+
+```
+schema: Dict[str, Any]
+```
+
+Selects values from a table with the provided column names and optional where clause.
+
+The schema parameter expects:
+
+| Key | Value |
+|-----|-------|
+| `columns` | A list of column names |
+| `where` | (optional) A list of lists of the column names, operator and values to filter the select. |
+
+Operators supported for where clauses are: `=, !=, <, >`
+
+As an example, to mimic the following select:
+
+```
+dev=# select * from states;
+ country |  state   | abbrev | somenum 
+---------+----------+--------+---------
+ USA     | Georgia  | GA     |      33
+ USA     | Virginia | VA     |      55
+(2 rows)
+
+```
+
+The schema passed to the connector would be:
+
+```
+{
+  "columns": [
+    "country",
+    "state",
+    "abbrev",
+    "somenum"
+  ]
+}
+```
+
+To mimic the following select:
+
+```
+dev=# select * from states where somenum = 33;
+ country |  state   | abbrev | somenum 
+---------+----------+--------+---------
+ USA     | Georgia  | GA     |      33
+ USA     | Virginia | VA     |      55
+(2 rows)
+
+```
+
+The schema passed to the connector would be:
+
+```
+{
+  "columns": [
+    "country",
+    "state",
+    "abbrev",
+    "somenum"
+  ],
+  "where": [
+    ["somenum", "=", 33]
+  ]
+}
+```

--- a/connectors/connector-postgresql/README.md
+++ b/connectors/connector-postgresql/README.md
@@ -164,7 +164,6 @@ dev=# select * from states where somenum = 33;
  country |  state   | abbrev | somenum 
 ---------+----------+--------+---------
  USA     | Georgia  | GA     |      33
- USA     | Virginia | VA     |      55
 (2 rows)
 
 ```

--- a/connectors/connector-postgresql/README.md
+++ b/connectors/connector-postgresql/README.md
@@ -183,3 +183,39 @@ The schema passed to the connector would be:
   ]
 }
 ```
+
+### DeleteValues
+
+Additional parameters:
+
+```
+schema: Dict[str, Any]
+```
+
+Deletes rows from a table with the provided optional where clause. The where clause is specified, and works, the same as described in `SelectValues`.
+
+
+### UpdateValues
+
+Additional parameters:
+
+```
+schema: Dict[str, Any]
+```
+
+Updates columns a table with the provided value and optional where clause. The where clause is specified, and works, the same as described in `SelectValues`.
+
+The schema expcets a `set` key with a value that is a dictionary. The keys in this dictionary are the column names and the values are the new value to set. 
+
+For example:
+
+```
+{
+  "set": {
+    "abbrev": "ZZ"
+  }, 
+  "where": [
+    ["abbrev", "=", "VA"]
+  ]
+}
+```

--- a/connectors/connector-postgresql/README.md
+++ b/connectors/connector-postgresql/README.md
@@ -2,7 +2,24 @@
 
 ## Commands
 
-### Create Table
+All commands require passing in the following parameters:
+
+```
+database_name: str
+database_host: str
+database_port: int
+database_user: str
+database_password: str
+table_name: str
+```
+
+### CreateTable
+
+Additional parameters:
+
+```
+schema: Dict[str, Any]
+```
 
 Creates a table with the provided column names and their [types](https://www.postgresql.org/docs/current/datatype.html).
 
@@ -25,7 +42,8 @@ dev=# \d states;
 The schema passed to the connector would be:
 
 ```
-{"column_definitions": [
+{
+  "column_definitions": [
     {
         "name": "country",
         "type": "varchar(255)",
@@ -42,5 +60,56 @@ The schema passed to the connector would be:
         "name": "somenum",
         "type": "int",
     }
-]}
+  ]
+}
+```
+
+### DropTable
+
+Drops a table.
+
+### InsertValues
+
+Additional parameters:
+
+```
+schema: Dict[str, Any]
+```
+
+Inserts values into a table with the provided column names and their values. Multiple records can be inserted per call.
+
+The schema parameter expects:
+
+| Key | Value |
+|-----|-------|
+| `columns` | A list of column names |
+| `values` | A list of lists of the values to insert. Order must match column order. |
+
+As an example, to insert the following data:
+
+```
+dev=# select * from states;
+ country |  state   | abbrev | somenum 
+---------+----------+--------+---------
+ USA     | Georgia  | GA     |      33
+ USA     | Virginia | VA     |      55
+(2 rows)
+
+```
+
+The schema passed to the connector would be:
+
+```
+{
+  "columns": [
+    "country",
+    "state",
+    "abbrev",
+    "somenum"
+  ], 
+  "values": [
+    ["USA", "Georgia", "GA", 33], 
+    ["USA", "Virginia", "VA", 55]
+  ]
+}
 ```

--- a/connectors/connector-postgresql/connector_postgresql/commands/createTable.py
+++ b/connectors/connector-postgresql/connector_postgresql/commands/createTable.py
@@ -38,10 +38,8 @@ class CreateTable(BaseCommand):
 
     def _column_definitions(self, schema):
         def column_defintion(column):
-            # TODO: allow column type/constraints to be specified
-            return f"{column} VARCHAR"
+            return f"{column['name']} {column['type']}"
 
-        column_names = schema["columns"]
-        column_definitions = map(column_defintion, column_names)
+        column_definitions = map(column_defintion, schema["column_definitions"])
         
         return ",".join(column_definitions)


### PR DESCRIPTION
Line item from the spreadsheet, this allows setting column types when creating a table. Also added a README to describe the schemas needed for the various endpoints.